### PR TITLE
Remove OS check for VMAgent, Update Otel version and Only download once.

### DIFF
--- a/remote_write/targets/common.go
+++ b/remote_write/targets/common.go
@@ -15,6 +15,7 @@ import (
 	"path"
 	"runtime"
 	"strings"
+	"sync"
 	"syscall"
 	"text/template"
 	"time"
@@ -28,7 +29,15 @@ type TargetOptions struct {
 	Timeout         time.Duration
 }
 
+var downloadMtx sync.Mutex
+
 func downloadBinary(urlPattern string, filenameInArchivePattern string) (string, error) {
+	downloadMtx.Lock()
+	defer downloadMtx.Unlock()
+	return downloadBinaryUnlocked(urlPattern, filenameInArchivePattern)
+}
+
+func downloadBinaryUnlocked(urlPattern string, filenameInArchivePattern string) (string, error) {
 	urlToDownload, err := instantiateTemplate(urlPattern)
 	if err != nil {
 		return "", nil

--- a/remote_write/targets/otel.go
+++ b/remote_write/targets/otel.go
@@ -5,7 +5,7 @@ import (
 	"os"
 )
 
-const otelDownloadURL = "https://github.com/open-telemetry/opentelemetry-collector/releases/download/v0.24.0/otelcol_{{.OS}}_{{.Arch}}"
+const otelDownloadURL = "https://github.com/open-telemetry/opentelemetry-collector/releases/download/v0.25.0/otelcol_{{.OS}}_{{.Arch}}"
 
 func RunOtelCollector(opts TargetOptions) error {
 	binary, err := downloadBinary(otelDownloadURL, "")

--- a/remote_write/targets/vmagent.go
+++ b/remote_write/targets/vmagent.go
@@ -3,17 +3,13 @@ package targets
 import (
 	"fmt"
 	"os"
-	"runtime"
 )
 
 const vmagentURL = "https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v1.58.0/vmutils-{{.Arch}}-v1.58.0.tar.gz"
 
 func RunVMAgent(opts TargetOptions) error {
-	// need mac builds https://github.com/VictoriaMetrics/VictoriaMetrics/issues/1042!
-	if runtime.GOOS != "linux" {
-		return fmt.Errorf("cannot run vmagent tests on non-linux: no builds are published")
-	}
-
+	// NB this won't work on a Mac - need mac builds https://github.com/VictoriaMetrics/VictoriaMetrics/issues/1042!
+	// If you build it yourself and stick it in the bin/ directory, the tests will work.
 	binary, err := downloadBinary(vmagentURL, "vmagent-prod")
 	if err != nil {
 		return err


### PR DESCRIPTION
You can build your own vmagent for mac and stick it in the bin/ dir, and the tests won't download it.

Signed-off-by: Tom Wilkie <tom@grafana.com>