### PR TITLE
Add test for retry behaviour: should retries 5xx, should not retry 4xx.

### DIFF
--- a/remote_write/cases/retries.go
+++ b/remote_write/cases/retries.go
@@ -1,0 +1,125 @@
+package cases
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/storage/remote"
+	"github.com/stretchr/testify/require"
+)
+
+// Retries500Test rejects the first remote write and checks it gets resent.
+func Retries500Test() Test {
+	var (
+		mtx    sync.Mutex
+		accept bool
+		ts     int64
+	)
+
+	return Test{
+		Name: "Retries500",
+		Metrics: metricHandler(prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+			Name: "now",
+		}, func() float64 {
+			return float64(time.Now().Unix() * 1000)
+		})),
+		Writes: func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mtx.Lock()
+				defer mtx.Unlock()
+
+				if accept {
+					next.ServeHTTP(w, r)
+					return
+				}
+
+				// We're going to pick a timestamp from this batch, and then make sure
+				// it gets resent.  First we need to decode this batch.
+				ts = getFirstTimestamp(w, r)
+				accept = true
+				http.Error(w, "internal server error", http.StatusInternalServerError)
+			})
+
+		},
+		Expected: func(t *testing.T, bs []Batch) {
+			found := false
+			forAllSamples(bs, func(s sample) {
+				if labelsContain(s.l, labels.FromStrings("__name__", "now")) && s.t == ts {
+					found = true
+				}
+			})
+			require.True(t, found, `failed to find sample that should have been retried`)
+		},
+	}
+}
+
+// Retries400Test rejects the first remote write and checks it doesn't get resent.
+func Retries400Test() Test {
+	var (
+		mtx    sync.Mutex
+		accept bool
+		ts     int64
+	)
+
+	return Test{
+		Name: "Retries400",
+		Metrics: metricHandler(prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+			Name: "now",
+		}, func() float64 {
+			return float64(time.Now().Unix() * 1000)
+		})),
+		Writes: func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mtx.Lock()
+				defer mtx.Unlock()
+
+				if accept {
+					next.ServeHTTP(w, r)
+					return
+				}
+
+				// We're going to pick a timestamp from this batch, and then make sure
+				// it gets resent.  First we need to decode this batch.
+				ts = getFirstTimestamp(w, r)
+				accept = true
+				http.Error(w, "bad request", http.StatusBadRequest)
+			})
+
+		},
+		Expected: func(t *testing.T, bs []Batch) {
+			found := false
+			forAllSamples(bs, func(s sample) {
+				if labelsContain(s.l, labels.FromStrings("__name__", "now")) && s.t == ts {
+					found = true
+				}
+			})
+			require.False(t, found, `found sample that should not have been retried`)
+		},
+	}
+}
+
+func getFirstTimestamp(w http.ResponseWriter, r *http.Request) int64 {
+	ap := Appendable{}
+	h := remote.NewWriteHandler(log.NewNopLogger(), &ap)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, r)
+	if rec.Code/100 != 2 {
+		http.Error(w, "", rec.Code)
+		return -1
+	}
+
+	// Find a sample for "now{}" and record its timestamp.
+	var ts int64 = -1
+	forAllSamples(ap.Batches, func(s sample) {
+		if labelsContain(s.l, labels.FromStrings("__name__", "now")) {
+			ts = s.t
+		}
+	})
+	return ts
+}

--- a/remote_write/main_test.go
+++ b/remote_write/main_test.go
@@ -52,10 +52,11 @@ var (
 		cases.TimestampTest,
 		cases.HeadersTest,
 		cases.OrderingTest,
+		cases.Retries500Test,
+		cases.Retries400Test,
 
 		// TODO:
 		// - Test labels have valid characters.
-		// - retry behaviour & status codes.
 	}
 )
 


### PR DESCRIPTION
```
--- FAIL: TestRemoteWrite (50.30s)
    --- PASS: TestRemoteWrite/grafana (0.00s)
        --- PASS: TestRemoteWrite/grafana/Retries400 (10.07s)
        --- PASS: TestRemoteWrite/grafana/Retries500 (10.08s)
    --- FAIL: TestRemoteWrite/otelcollector (0.01s)
        --- PASS: TestRemoteWrite/otelcollector/Retries400 (10.02s)
        --- FAIL: TestRemoteWrite/otelcollector/Retries500 (10.02s)
    --- PASS: TestRemoteWrite/prometheus (0.01s)
        --- PASS: TestRemoteWrite/prometheus/Retries400 (10.05s)
        --- PASS: TestRemoteWrite/prometheus/Retries500 (10.10s)
    --- FAIL: TestRemoteWrite/telegraf (0.01s)
        --- PASS: TestRemoteWrite/telegraf/Retries400 (10.02s)
        --- FAIL: TestRemoteWrite/telegraf/Retries500 (10.02s)
    --- FAIL: TestRemoteWrite/vector (0.01s)
        --- PASS: TestRemoteWrite/vector/Retries400 (10.03s)
        --- FAIL: TestRemoteWrite/vector/Retries500 (10.03s)
```


Signed-off-by: Tom Wilkie <tom@grafana.com>