### PR TITLE
Allow overriding the Host header

### DIFF
--- a/promql/cmd/promql-compliance-tester/main.go
+++ b/promql/cmd/promql-compliance-tester/main.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -48,7 +49,11 @@ func (rt roundTripperWithSettings) RoundTrip(req *http.Request) (*http.Response,
 	}
 
 	for key, value := range rt.headers {
-		req.Header.Add(key, value)
+		if strings.ToLower(key) == "host" {
+			req.Host = value
+		} else {
+			req.Header.Add(key, value)
+		}
 	}
 	return http.DefaultTransport.RoundTrip(req)
 }


### PR DESCRIPTION
This was required for making AMP testing work through the AWS SigV4 proxy.

Signed-off-by: Julius Volz <julius.volz@gmail.com>