### PR TITLE
Allow config file splitting, update test cases

### DIFF
--- a/promql/cmd/promql-compliance-tester/main.go
+++ b/promql/cmd/promql-compliance-tester/main.go
@@ -53,8 +53,20 @@ func (rt roundTripperWithSettings) RoundTrip(req *http.Request) (*http.Response,
 	return http.DefaultTransport.RoundTrip(req)
 }
 
+type arrayFlags []string
+
+func (i *arrayFlags) String() string {
+	return "my string representation"
+}
+
+func (i *arrayFlags) Set(value string) error {
+	*i = append(*i, value)
+	return nil
+}
+
 func main() {
-	configFile := flag.String("config-file", "promql-compliance-tester.yml", "The path to the configuration file.")
+	var configFiles arrayFlags
+	flag.Var(&configFiles, "config-file", "The path to the configuration file. If repeated, the specified files will be concatenated before YAML parsing.")
 	outputFormat := flag.String("output-format", "text", "The comparison output format. Valid values: [text, html, json]")
 	outputHTMLTemplate := flag.String("output-html-template", "./output/example-output.html", "The HTML template to use when using HTML as the output format.")
 	outputPassing := flag.Bool("output-passing", false, "Whether to also include passing test cases in the output.")
@@ -79,7 +91,7 @@ func main() {
 		log.Fatalf("Invalid output format %q", *outputFormat)
 	}
 
-	cfg, err := config.LoadFromFile(*configFile)
+	cfg, err := config.LoadFromFiles(configFiles)
 	if err != nil {
 		log.Fatalf("Error loading configuration file: %v", err)
 	}

--- a/promql/config/config.go
+++ b/promql/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"io/ioutil"
 
 	"github.com/pkg/errors"
@@ -56,15 +57,21 @@ type TestCase struct {
 	ShouldFail     bool     `yaml:"should_fail,omitempty"`
 }
 
-// LoadFromFile parses the given YAML file into a Config.
-func LoadFromFile(filename string) (*Config, error) {
-	content, err := ioutil.ReadFile(filename)
-	if err != nil {
-		return nil, err
+// LoadFromFiles parses the given YAML files into a Config.
+func LoadFromFiles(filenames []string) (*Config, error) {
+	var buf bytes.Buffer
+	for _, f := range filenames {
+		content, err := ioutil.ReadFile(f)
+		if err != nil {
+			return nil, errors.Wrapf(err, "reading config file %s", f)
+		}
+		if _, err := buf.Write(content); err != nil {
+			return nil, errors.Wrapf(err, "appending config file %s to buffer", f)
+		}
 	}
-	cfg, err := Load(content)
+	cfg, err := Load(buf.Bytes())
 	if err != nil {
-		return nil, errors.Wrapf(err, "parsing YAML file %s", filename)
+		return nil, errors.Wrapf(err, "parsing YAML files %s", filenames)
 	}
 	return cfg, nil
 }

--- a/promql/promql-test-queries.yml
+++ b/promql/promql-test-queries.yml
@@ -1,79 +1,4 @@
-reference_target_config:
-  query_url: 'http://localhost:9090'
-
-test_target_config:
-  # UNCOMMENT FOR GRAFANA CLOUD:
-  # query_url: 'https://<instance-name>.grafana.net/api/prom'
-  # basic_auth_user: <user-id>
-  # basic_auth_pass: '<password>'
-  #
-  # UNCOMMENT FOR CHRONOSPHERE:
-  # query_url: 'https://<instance-name>.chronosphere.io/data/metrics'
-  # headers:
-  #   Authorization: 'Bearer <bearer-token>'
-  #
-  # UNCOMMENT FOR CORTEX:
-  # query_url: 'http://localhost:9009/api/prom'
-  #
-  # UNCOMMENT FOR VICTORIAMETRICS:
-  # query_url: 'http://localhost:8428'
-  #
-  # UNCOMMENT FOR TIMESCALEDB:
-  # query_url: 'http://localhost:9201'
-  #
-  # UNCOMMENT FOR THANOS:
-  # query_url: 'http://localhost:20902'
-  #
-  # UNCOMMENT FOR NEW RELIC:
-  # query_url: https://prometheus-api.newrelic.com
-  # headers:
-  #  X-Query-Key: <query-key>
-  #
-  # UNCOMMENT FOR M3:
-  # query_url: http://localhost:7201
-  #
-  # UNCOMMENT FOR METRICFIRE:
-  # query_url: https://www.hostedgraphite.com/<account-id>/v2/prometheus/query
-  # headers:
-  #   accept-language: 'en-US,en'
-  #   accept: 'application/json'
-  #   accept-encoding: 'br'
-  #   Cookie: 'sessionid=<session-id>;'
-
-query_tweaks:
-  # UNCOMMENT FOR GRAFANA CLOUD:
-  # - note: 'Grafana Cloud aligns incoming query timestamps to a multiple of the query resolution step to enable caching.'
-  #   truncate_timestamps_to_ms: 10000
-  #
-  # UNCOMMENT FOR THANOS:
-  # - note: 'Thanos requires adding "external_labels" to distinguish Prometheus servers, leading to extra labels in query results that need to be stripped before comparing results.'
-  #   no_bug: true
-  #   drop_result_labels:
-  #   - prometheus
-  #
-  # UNCOMMENT FOR VICTORIAMETRICS:
-  # - note: 'VictoriaMetrics aligns incoming query timestamps to a multiple of the query resolution step.'
-  #   align_timestamps_to_step: true
-  #
-  # UNCOMMENT FOR NEW RELIC:
-  # - note: 'New Relic is sometimes off by 1ms when parsing floating point start/end timestamps.'
-  #   truncate_timestamps_to_ms: 1000
-  # - note: 'New Relic adds a "prometheus_server" label to distinguish Prometheus servers, leading to extra labels in query results. These need to be stripped before comparisons.'
-  #   no_bug: true
-  #   drop_result_labels:
-  #     - prometheus_server
-  # - note: 'New Relic omits the first resolution step in the output.'
-  #   ignore_first_step: true
-  #
-  # UNCOMMENT FOR METRICFIRE:
-  # - note: 'MetricFire is sometimes off by 1ms when parsing floating point start/end timestamps. See underlying Cortex issue https://github.com/cortexproject/cortex/issues/2932, which still needs to be rolled out in MetricFire.'
-  #   truncate_timestamps_to_ms: 1000
-  #
-  # UNCOMMENT FOR CHRONOSPHERE:
-  # - note: 'Chronosphere rounds incoming query timestamps to a full second.'
-  #   truncate_timestamps_to_ms: 1000
-
-# This set of example queries expects data from the following Prometheus configuration file  to have
+# This set of example queries expects data from the following Prometheus configuration file to have
 # been ingested into both a vanilla Prometheus server and the third-party system for several hours,
 # so that the tester can compare query results from both systems over a range of time:
 #
@@ -238,8 +163,8 @@ test_cases:
     variant_args: ['binOp']
 
   # Functions.
-  - query: '{{.simpleAggrOp}}_over_time(demo_memory_usage_bytes[{{.range}}])'
-    variant_args: ['simpleAggrOp', 'range']
+  - query: '{{.simpleTimeAggrOp}}_over_time(demo_memory_usage_bytes[{{.range}}])'
+    variant_args: ['simpleTimeAggrOp', 'range']
   - query: 'quantile_over_time({{.quantile}}, demo_memory_usage_bytes[{{.range}}])'
     variant_args: ['quantile', 'range']
   - query: 'timestamp(demo_num_cpus)'
@@ -293,6 +218,10 @@ test_cases:
     variant_args: ['instantRateFunc', 'range']
   - query: '{{.clampFunc}}(demo_memory_usage_bytes, 2)'
     variant_args: ['clampFunc']
+  - query: 'clamp(demo_memory_usage_bytes, 0, 1)'
+  - query: 'clamp(demo_memory_usage_bytes, 0, 1000000000000)'
+  - query: 'clamp(demo_memory_usage_bytes, 1000000000000, 0)'
+  - query: 'clamp(demo_memory_usage_bytes, 1000000000000, 1000000000000)'
   - query: 'resets(demo_cpu_usage_seconds_total[{{.range}}])'
     variant_args: ['range']
   - query: 'changes(demo_batch_last_success_timestamp_seconds[{{.range}}])'
@@ -308,6 +237,9 @@ test_cases:
     query: 'histogram_quantile(0.9, {__name__=~"demo_api_request_duration_seconds_.+"})'
   - query: 'holt_winters(demo_disk_usage_bytes[10m], {{.smoothingFactor}}, {{.trendFactor}})'
     variant_args: ['smoothingFactor', 'trendFactor']
+  - query: 'count_values("value", demo_api_request_duration_seconds_bucket)'
+  - query: 'absent(demo_memory_usage_bytes)'
+  - query: 'absent(nonexistent_metric_name)'
 
   # Subqueries.
   - query: 'max_over_time((time() - max(demo_batch_last_success_timestamp_seconds) < 1000)[5m:10s] offset 5m)'

--- a/promql/test-amp.yml
+++ b/promql/test-amp.yml
@@ -1,0 +1,11 @@
+reference_target_config:
+  query_url: 'http://localhost:9090'
+
+test_target_config:
+  query_url: 'http://localhost:8080/workspaces/<workspace-id>'
+  headers:
+    Host: aps-workspaces.<region>.amazonaws.com
+
+query_tweaks:
+  - note: 'AMP aligns incoming query timestamps to a multiple of the query resolution step to enable caching.'
+    truncate_timestamps_to_ms: 10000

--- a/promql/test-chronosphere.yml
+++ b/promql/test-chronosphere.yml
@@ -1,0 +1,7 @@
+reference_target_config:
+  query_url: 'http://localhost:9090'
+
+test_target_config:
+  query_url: 'https://<env>.chronosphere.io/data/metrics'
+  headers:
+    Authorization: 'Bearer <bearer-token>'

--- a/promql/test-cortex.yml
+++ b/promql/test-cortex.yml
@@ -1,0 +1,5 @@
+reference_target_config:
+  query_url: 'http://localhost:9090'
+
+test_target_config:
+  query_url: 'http://localhost:9009/api/prom'

--- a/promql/test-gmp.yml
+++ b/promql/test-gmp.yml
@@ -1,0 +1,15 @@
+reference_target_config:
+  query_url: 'http://localhost:9090'
+
+test_target_config:
+  query_url: 'https://monitoring.googleapis.com/v1/projects/promql-testing/location/global/prometheus'
+  headers:
+    Authorization: 'Bearer <bearer-token>'
+    X-Goog-User-Project: promql-testing
+
+query_tweaks:
+  - note: 'GMP requires adding "external_labels" for the location and project ID that need to be stripped before comparing results.'
+    no_bug: true
+    drop_result_labels:
+      - location
+      - project_id

--- a/promql/test-grafana-cloud.yml
+++ b/promql/test-grafana-cloud.yml
@@ -1,0 +1,7 @@
+reference_target_config:
+  query_url: 'http://localhost:9090'
+
+test_target_config:
+  query_url: 'https://<cluster-name>.grafana.net/api/prom'
+  basic_auth_user: '<user-id>'
+  basic_auth_pass: '<password>'

--- a/promql/test-m3.yml
+++ b/promql/test-m3.yml
@@ -1,0 +1,5 @@
+reference_target_config:
+  query_url: 'http://localhost:9091'
+
+test_target_config:
+  query_url: http://localhost:7201

--- a/promql/test-new-relic.yml
+++ b/promql/test-new-relic.yml
@@ -1,0 +1,17 @@
+reference_target_config:
+  query_url: 'http://localhost:9090'
+
+test_target_config:
+  query_url: https://prometheus-api.<region>.newrelic.com
+  headers:
+   X-Query-Key: <insights-query-key>
+
+query_tweaks:
+  - note: 'New Relic is sometimes off by 1ms when parsing floating point start/end timestamps.'
+    truncate_timestamps_to_ms: 1000
+  - note: 'New Relic adds a "prometheus_server" label to distinguish Prometheus servers, leading to extra labels in query results. These need to be stripped before comparisons.'
+    no_bug: true
+    drop_result_labels:
+      - prometheus_server
+  - note: 'New Relic omits the first resolution step in the output.'
+    ignore_first_step: true

--- a/promql/test-promscale.yml
+++ b/promql/test-promscale.yml
@@ -1,0 +1,5 @@
+reference_target_config:
+  query_url: 'http://localhost:9090'
+
+test_target_config:
+  query_url: 'http://localhost:9201'

--- a/promql/test-sysdig.yml
+++ b/promql/test-sysdig.yml
@@ -1,0 +1,15 @@
+reference_target_config:
+  query_url: 'http://localhost:9090'
+
+test_target_config:
+  query_url: https://<region>.app.sysdig.com/prometheus
+  headers:
+    Authorization: 'Bearer <bearer-token>'
+
+query_tweaks:
+  - note: 'All samples and queries are aligned to a 10-second grid in Sysdig.'
+    align_timestamps_to_step: true
+  - note: 'Sysdig adds a "remote_write" label to data coming from Prometheus, which needs to be stripped before comparing results.'
+    no_bug: true
+    drop_result_labels:
+     - remote_write

--- a/promql/test-thanos.yml
+++ b/promql/test-thanos.yml
@@ -1,0 +1,11 @@
+reference_target_config:
+  query_url: 'http://localhost:9090'
+
+test_target_config:
+  query_url: 'http://localhost:20902'
+
+query_tweaks:
+  - note: 'Thanos requires adding "external_labels" to distinguish Prometheus servers, leading to extra labels in query results that need to be stripped before comparing results.'
+    no_bug: true
+    drop_result_labels:
+    - prometheus

--- a/promql/test-victoriametrics.yml
+++ b/promql/test-victoriametrics.yml
@@ -1,0 +1,9 @@
+reference_target_config:
+  query_url: 'http://localhost:9090'
+
+test_target_config:
+  query_url: 'http://localhost:8428'
+
+query_tweaks:
+  - note: 'VictoriaMetrics aligns incoming query timestamps to a multiple of the query resolution step.'
+    align_timestamps_to_step: true

--- a/promql/test-wavefront.yml
+++ b/promql/test-wavefront.yml
@@ -1,0 +1,11 @@
+reference_target_config:
+  query_url: 'http://localhost:9090/'
+
+test_target_config:
+  query_url: https://tracing.wavefront.com/
+  headers:
+    Authorization: 'Bearer <bearer-token>'
+
+query_tweaks:
+  - note: 'Wavefront is sometimes off by 1ms when parsing floating point start/end timestamps.'
+    truncate_timestamps_to_ms: 1000

--- a/promql/testcases/expand.go
+++ b/promql/testcases/expand.go
@@ -42,11 +42,11 @@ import (
 )
 
 var testVariantArgs = map[string][]string{
-	"range":  {"1s", "15s", "1m", "5m", "15m", "1h"},
-	"offset": {"1m", "5m", "10m"},
-	// TODO: Add "group" aggregator and new duration formats, but it is so new that vendor implementations need time to catch up first.
-	"simpleAggrOp": {"sum", "avg", "max", "min", "count", "stddev", "stdvar"},
-	"topBottomOp":  {"topk", "bottomk"},
+	"range":            {"1s", "15s", "1m", "5m", "15m", "1h"},
+	"offset":           {"1m", "5m", "10m"},
+	"simpleAggrOp":     {"sum", "avg", "max", "min", "count", "stddev", "stdvar"},
+	"simpleTimeAggrOp": {"sum", "avg", "max", "min", "count", "stddev", "stdvar", "absent", "last"},
+	"topBottomOp":      {"topk", "bottomk"},
 	"quantile": {
 		"-0.5",
 		"0.1",


### PR DESCRIPTION
Sorry, this is in one commit because I didn't do a separate update of test
cases in the old, non-split config file.

You can now pass -config-file multiple times, leading for the mentioned
files to be concatenated before YAML parsing happens.

Signed-off-by: Julius Volz <julius.volz@gmail.com>