### PR TITLE
Update Alert-Generator spec: no inactive alerts in the GET API

### DIFF
--- a/alert_generator/specification.md
+++ b/alert_generator/specification.md
@@ -330,7 +330,7 @@ An example for a custom field here that is used by Prometheus is `”file”: �
     * `"pending"`: at least 1 alert in the rule in `pending` state and no other alert in `firing` state.
     * `"firing"`: at least 1 alert in the rule in `firing` state.
     * `"inactive"`: no alert in the rule in `firing` or `pending` state.
-* `alerts` is the list of all the alerts in this rule that are currently `pending` or `firing` including `inactive` alerts that are still being sent to the alertmanager (i.e. up to 15m since `ResolvedAt` until next evaluation and no new alerts with same labels as `inactive` alert).
+* `alerts` is the list of all the alerts in this rule that are currently `pending` or `firing`.
 * `lastError` MUST be omitted or empty `""` when `health` is `"ok"`. `lastError` MUST be non empty for other `health` states containing the error faced while executing the rule.
 
 


### PR DESCRIPTION
Noticed this when working on the test suite.

Code references:

For `/api/v1/alerts`
https://github.com/prometheus/prometheus/blob/a961062c37f1675d5925d8b74ddda0a6322ed82d/web/api/v1/api.go#L1064

For `/api/v1/rules`
https://github.com/prometheus/prometheus/blob/a961062c37f1675d5925d8b74ddda0a6322ed82d/web/api/v1/api.go#L1242