### PR TITLE
otel flag changed

### DIFF
--- a/remote_write_sender/targets/otel.go
+++ b/remote_write_sender/targets/otel.go
@@ -43,5 +43,5 @@ service:
 	}
 	defer os.Remove(configFileName)
 
-	return runCommand(binary, opts.Timeout, `--metrics-addr=:0`, fmt.Sprintf("--config=%s", configFileName))
+	return runCommand(binary, opts.Timeout, `--set=service.telemetry.metrics.address=:0`, fmt.Sprintf("--config=%s", configFileName))
 }


### PR DESCRIPTION
The `metrics-addr` is going away in the next release (see [breaking changes](https://github.com/open-telemetry/opentelemetry-collector/blob/main/CHANGELOG.md#-breaking-changes-)). It has been replaced by `--set=service.telemetry.metrics.address`