### PR TITLE
Add Sigv4 support to alert_generator tests

### DIFF
--- a/alert_generator/config/config.go
+++ b/alert_generator/config/config.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/pkg/errors"
+	"github.com/prometheus/common/sigv4"
 	"gopkg.in/yaml.v2"
 )
 
@@ -37,14 +38,15 @@ type Settings struct {
 }
 
 type Auth struct {
-	RemoteWrite       BasicAuth `yaml:"remote_write"`
-	RulesAndAlertsAPI BasicAuth `yaml:"rules_and_alerts_api"`
-	Query             BasicAuth `yaml:"query"`
+	RemoteWrite       AuthConfig `yaml:"remote_write"`
+	RulesAndAlertsAPI AuthConfig `yaml:"rules_and_alerts_api"`
+	Query             AuthConfig `yaml:"query"`
 }
 
-type BasicAuth struct {
-	BasicAuthUser string `yaml:"basic_auth_user"`
-	BasicAuthPass string `yaml:"basic_auth_pass"`
+type AuthConfig struct {
+	SigV4Config   *sigv4.SigV4Config `yaml:"sigv4"`
+	BasicAuthUser string             `yaml:"basic_auth_user"`
+	BasicAuthPass string             `yaml:"basic_auth_pass"`
 }
 
 func validateConfig(cfg *Config) (*Config, error) {

--- a/alert_generator/remote_write.go
+++ b/alert_generator/remote_write.go
@@ -41,6 +41,7 @@ func NewRemoteWriter(cfg agconfig.Config, logger log.Logger) (*RemoteWriter, err
 		HTTPClientConfig: config.HTTPClientConfig{
 			BasicAuth: baseAuth,
 		},
+		SigV4Config: cfg.Auth.RemoteWrite.SigV4Config,
 	})
 	if err != nil {
 		return nil, err

--- a/alert_generator/test-amazon-managed-service-for-prometheus.yaml
+++ b/alert_generator/test-amazon-managed-service-for-prometheus.yaml
@@ -1,0 +1,17 @@
+settings:
+  remote_write_url: https://aps-workspaces.us-west-2.amazonaws.com/workspaces/<workspace-id>/api/v1/remote_write
+  query_base_url: https://aps-workspaces.us-west-2.amazonaws.com/workspaces/<workspace-id>
+  rules_and_alerts_api_base_url: https://aps-workspaces.us-west-2.amazonaws.com/workspaces/<workspace-id>
+  # Currently it's too hard to perform alert reception check, so we disable it for now.
+  disable_alerts_reception_check: true
+
+auth:
+  remote_write:
+    sigv4:
+      region: us-west-2
+  rules_and_alerts_api:
+    sigv4:
+      region: us-west-2
+  query:
+    sigv4:
+      region: us-west-2

--- a/alert_generator/test-amp.yaml
+++ b/alert_generator/test-amp.yaml
@@ -1,3 +1,4 @@
+# This is example configuration for Amazon Managed Service for Prometheus.
 settings:
   remote_write_url: https://aps-workspaces.us-west-2.amazonaws.com/workspaces/<workspace-id>/api/v1/remote_write
   query_base_url: https://aps-workspaces.us-west-2.amazonaws.com/workspaces/<workspace-id>

--- a/alert_generator/test-example.yaml
+++ b/alert_generator/test-example.yaml
@@ -21,16 +21,43 @@ settings:
 auth:
   # For remote writing.
   remote_write:
-    basic_auth_user: '<user-id>'
-    basic_auth_pass: '<password>'
+    basic_auth_user: "<user-id>"
+    basic_auth_pass: "<password>"
+
+    # You can only specify either basic auth or sigv4, not both.
+    # To use the default credentials from the AWS SDK, use `sigv4: {}`.
+    sigv4:
+      region: <AWS region>
+      access_key: <AWS access key>
+      secret_key: <AWS secret key>
+      profile: <AWS profile name>
+      role_arn: <AWS role ARN>
   # To access <rules_and_alerts_api_base_url>/api/v1/rules and <rules_and_alerts_api_base_url>/api/v1/alerts.
   rules_and_alerts_api:
-    basic_auth_user: '<user-id>'
-    basic_auth_pass: '<password>'
+    basic_auth_user: "<user-id>"
+    basic_auth_pass: "<password>"
+
+    # You can only specify either basic auth or sigv4, not both.
+    # To use the default credentials from the AWS SDK, use `sigv4: {}`.
+    sigv4:
+      region: <AWS region>
+      access_key: <AWS access key>
+      secret_key: <AWS secret key>
+      profile: <AWS profile name>
+      role_arn: <AWS role ARN>
   # To access <query_base_url>/query.
   query:
-    basic_auth_user: '<user-id>'
-    basic_auth_pass: '<password>'
+    basic_auth_user: "<user-id>"
+    basic_auth_pass: "<password>"
+
+    # You can only specify either basic auth or sigv4, not both.
+    # To use the default credentials from the AWS SDK, use `sigv4: {}`.
+    sigv4:
+      rregion: <AWS region>
+      access_key: <AWS access key>
+      secret_key: <AWS secret key>
+      profile: <AWS profile name>
+      role_arn: <AWS role ARN>
 
 # By default all test cases will be enabled and you don't need to set this.
 # But if you want to debug a particular or a set of rule groups, you can set this


### PR DESCRIPTION
Adding sigv4 support to allow testing against [Amazon Managed Service for Prometheus](https://aws.amazon.com/prometheus/) easier. 

Signed-off-by: Alvin Lin <alvinlin@amazon.com>