### PR TITLE
[alert_generator] Allow writing custom parsers for the alert payload

### DIFF
--- a/alert_generator/README.md
+++ b/alert_generator/README.md
@@ -56,6 +56,10 @@ Note:
 
 #### Step 5
 
+If your software send alerts in a format that is not parsable by any of the provided parsers in [alert_message_parsers.go](./alert_message_parsers.go), you can extend that file to include your custom parser and mention that name in the config file.
+
+#### Step 6
+
 Now that everything is set up, you can run the test as follows
 
 ```bash

--- a/alert_generator/alert_message_parsers.go
+++ b/alert_generator/alert_message_parsers.go
@@ -1,0 +1,41 @@
+package testsuite
+
+import (
+	"encoding/json"
+	"github.com/prometheus/alertmanager/notify/webhook"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/notifier"
+)
+
+// AlertMessageParsers is a map of the parser name to the parser function.
+// The parser name is the one to be used in the config file.
+// You can extend this map to include your custom parser and it will be
+// matched with the config file.
+var AlertMessageParsers = map[string]AlertMessageParser{
+	// This parses the alert payload sent by Prometheus.
+	"default": func(b []byte) ([]notifier.Alert, error) {
+		var alerts []notifier.Alert
+		err := json.Unmarshal(b, &alerts)
+		return alerts, err
+	},
+
+	// This parses the alert payload sent by Prometheus Alertmanager.
+	"alertmanager": func(b []byte) ([]notifier.Alert, error) {
+		msg := webhook.Message{}
+		err := json.Unmarshal(b, &msg)
+		if err != nil {
+			return nil, err
+		}
+		alerts := make([]notifier.Alert, 0, len(msg.Alerts))
+		for _, al := range msg.Alerts {
+			alerts = append(alerts, notifier.Alert{
+				Labels:       labels.FromMap(al.Labels),
+				Annotations:  labels.FromMap(al.Annotations),
+				StartsAt:     al.StartsAt,
+				EndsAt:       al.EndsAt,
+				GeneratorURL: al.GeneratorURL,
+			})
+		}
+		return alerts, nil
+	},
+}

--- a/alert_generator/cmd/alert_generator_compliance_tester/main.go
+++ b/alert_generator/cmd/alert_generator_compliance_tester/main.go
@@ -42,10 +42,21 @@ func main() {
 		}
 	}
 
+	if cfg.Settings.AlertMessageParser == "" {
+		cfg.Settings.AlertMessageParser = "default"
+	}
+
+	alertMessageParser, ok := testsuite.AlertMessageParsers[cfg.Settings.AlertMessageParser]
+	if !ok {
+		level.Error(log).Log("msg", "Alert message parser not found", "name", cfg.Settings.AlertMessageParser)
+		os.Exit(1)
+	}
+
 	t, err := testsuite.NewTestSuite(testsuite.TestSuiteOptions{
-		Logger: log,
-		Cases:  casesToRun,
-		Config: *cfg,
+		Logger:             log,
+		Cases:              casesToRun,
+		Config:             *cfg,
+		AlertMessageParser: alertMessageParser,
 	})
 	if err != nil {
 		level.Error(log).Log("msg", "Failed to start the test suite", "err", err)

--- a/alert_generator/config/config.go
+++ b/alert_generator/config/config.go
@@ -32,6 +32,8 @@ type Settings struct {
 	DisableAlertsMetricsCheck   bool `yaml:"disable_alerts_metrics_check"`
 	DisableAlertsReceptionCheck bool `yaml:"disable_alerts_reception_check"`
 
+	AlertMessageParser string `yaml:"alert_message_parser"`
+
 	//APIHeaders         map[string]string `yaml:"api_headers"`
 	//QueryHeaders       map[string]string `yaml:"query_headers"`
 	//RemoteWriteHeaders map[string]string `yaml:"remote_write_headers"`

--- a/alert_generator/go.mod
+++ b/alert_generator/go.mod
@@ -47,12 +47,12 @@ require (
 	github.com/prometheus/client_golang v1.12.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1
-	github.com/prometheus/common/sigv4 v0.1.0 // indirect
+	github.com/prometheus/common/sigv4 v0.1.0
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/prometheus/prometheus v1.8.2-0.20220125113948-fe06f16c116a
 	github.com/stretchr/testify v1.7.0
 	go.mongodb.org/mongo-driver v1.7.5 // indirect
-	go.uber.org/atomic v1.9.0 // indirect
+	go.uber.org/atomic v1.9.0
 	go.uber.org/goleak v1.1.12 // indirect
 	golang.org/x/net v0.0.0-20220105145211-5b0dc2dfae98 // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
@@ -62,7 +62,7 @@ require (
 	golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )
 

--- a/alert_generator/specification.md
+++ b/alert_generator/specification.md
@@ -248,8 +248,9 @@ This implies that the `inactive` alert MUST be sent continuously with a fixed in
 
 `ResendDelay` acts as a minimum interval while the actual interval MUST be the first >0 multiple of the group interval that is more than or equal to `ResendDelay`.
 
-### Payload Format to Send Alerts to Alertmanager
-The alerts MUST be sent in the following JSON format to the alertmanager
+### Payload Format to Send from the Alert Generator
+
+The alerts can be sent out in any format as required by the software while it MUST be translatable to the following JSON format
 
 ```
 [

--- a/alert_generator/test-example.yaml
+++ b/alert_generator/test-example.yaml
@@ -17,6 +17,10 @@ settings:
   disable_alerts_metrics_check: false
   # Set to true to disable the check of alert reception.
   disable_alerts_reception_check: false
+  # Parser to use for the alert payload.
+  # Refer ./alert_message_parsers.go for available options, or implement your own in that file.
+  # The default value is `default` when not set.
+  alert_message_parser: default
 
 auth:
   # For remote writing.

--- a/alert_generator/test-prometheus.yaml
+++ b/alert_generator/test-prometheus.yaml
@@ -3,3 +3,4 @@ settings:
   query_base_url: http://localhost:9090
   rules_and_alerts_api_base_url: http://localhost:9090
   alert_reception_server_port: 8080
+  alert_message_parser: default

--- a/alert_generator/testsuite.go
+++ b/alert_generator/testsuite.go
@@ -46,6 +46,8 @@ type TestSuiteOptions struct {
 	Cases []cases.TestCase
 
 	Config config.Config
+
+	AlertMessageParser AlertMessageParser
 }
 
 func NewTestSuite(opts TestSuiteOptions) (*TestSuite, error) {
@@ -60,7 +62,7 @@ func NewTestSuite(opts TestSuiteOptions) (*TestSuite, error) {
 		ruleGroupTests:      make(map[string]cases.TestCase, len(opts.Cases)),
 		ruleGroupTestErrors: make(map[string][]error),
 		stopc:               make(chan struct{}),
-		as:                  newAlertsServer(opts.Config.Settings.AlertReceptionServerPort, opts.Config.Settings.DisableAlertsReceptionCheck, opts.Logger),
+		as:                  newAlertsServer(opts.Config.Settings.AlertReceptionServerPort, opts.Config.Settings.DisableAlertsReceptionCheck, opts.Logger, opts.AlertMessageParser),
 	}
 
 	m.remoteWriter, err = NewRemoteWriter(opts.Config, opts.Logger)
@@ -119,6 +121,10 @@ func validateOpts(opts TestSuiteOptions) error {
 		opts.Config.Settings.DisableAlertsMetricsCheck &&
 		opts.Config.Settings.DisableAlertsReceptionCheck {
 		return errors.New("all checks are disabled, at least one check should be enabled")
+	}
+
+	if opts.AlertMessageParser == nil {
+		return errors.New("AlertMessageParser is not set")
 	}
 
 	seenRuleGroups := make(map[string]bool)


### PR DESCRIPTION
This PR adds an option to custom parse the alert payload into the Go struct that we desire.

More context in https://groups.google.com/g/prometheus-developers/c/dBbKTnaSg_4

Note: this also updates the spec to reflect the changes in the requirements of the alert payload