### PR TITLE
Allow querying for negative offsets

### DIFF
--- a/promql/promql-test-queries.yml
+++ b/promql/promql-test-queries.yml
@@ -59,7 +59,6 @@ test_cases:
     variant_args: ['offset']
   - query: 'demo_memory_usage_bytes offset -{{.offset}}'
     variant_args: ['offset']
-    should_fail: true
   # Test staleness handling.
   - query: demo_intermittent_metric
 


### PR DESCRIPTION
Prometheus 2.33 started to allow negative offsets, so we need to mark queries
with negative offsets as valid now.

Signed-off-by: Julius Volz <julius.volz@gmail.com>