### PR TITLE
[alert_generator] Fix tolerance for matching end time of resolved alert

### DIFF
--- a/alert_generator/cases/expected_alert.go
+++ b/alert_generator/cases/expected_alert.go
@@ -86,7 +86,7 @@ func (ea *ExpectedAlert) Matches(now time.Time, a notifier.Alert) (err error) {
 		// Since EndsAt is w.r.t. the current time for a firing alert, if it does not match the expEndsAt,
 		// we need to consider any delay in sending the alert in case the alert was firing.
 		if !(ea.matchesWithinTolerance(expEndsAt, a.EndsAt) || ea.matchesWithinTolerance(expEndsAt.Add(-2*MaxRTT), a.EndsAt)) &&
-			(ea.Resolved || !ea.matchesWithinTolerance(expEndsAt.Add(-MaxRTT), a.EndsAt)) {
+			(ea.Resolved || !ea.matchesWithinTolerance(expEndsAt.Add(-2*MaxRTT), a.EndsAt)) {
 			return fmt.Errorf("mismatch in EndsAt, expected range: [%s, %s], got: %s",
 				expEndsAt.Format(time.RFC3339Nano),
 				expEndsAt.Add(ea.TimeTolerance).Format(time.RFC3339Nano),


### PR DESCRIPTION
We are using `2*MaxRTT` for firing alert while it was just `MaxRTT` for resolved. This PR fixes it.