### PR TITLE
Remove ioutil from alert_generator

### DIFF
--- a/alert_generator/cmd/rule_config_builder/main.go
+++ b/alert_generator/cmd/rule_config_builder/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -44,7 +43,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	err = ioutil.WriteFile(path, b, fs.ModePerm)
+	err = os.WriteFile(path, b, fs.ModePerm)
 	if err != nil {
 		level.Error(log).Log("msg", "Failed to write the rules file", "err", err)
 		os.Exit(1)

--- a/alert_generator/config/config.go
+++ b/alert_generator/config/config.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 
 	"github.com/pkg/errors"
@@ -98,7 +98,7 @@ func validateConfig(cfg *Config) (*Config, error) {
 
 // LoadFromFile parses the given YAML file into a Config.
 func LoadFromFile(fname string) (*Config, error) {
-	content, err := ioutil.ReadFile(fname)
+	content, err := os.ReadFile(fname)
 	if err != nil {
 		return nil, errors.Wrapf(err, "reading config file %s", fname)
 	}

--- a/alert_generator/server.go
+++ b/alert_generator/server.go
@@ -1,7 +1,7 @@
 package testsuite
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sort"
 	"sync"
@@ -85,7 +85,7 @@ func newAlertsServer(port string, disabled bool, logger log.Logger, messageParse
 
 func (as *alertsServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	now := time.Now().UTC()
-	b, err := ioutil.ReadAll(req.Body)
+	b, err := io.ReadAll(req.Body)
 	if err != nil {
 		level.Error(as.logger).Log("msg", "Error in reading request body", "err", err.Error())
 		res.WriteHeader(http.StatusBadRequest) // Or is it 500?

--- a/alert_generator/utils.go
+++ b/alert_generator/utils.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -49,7 +49,7 @@ func DoGetRequest(u string, auth config.AuthConfig) ([]byte, error) {
 		return nil, errors.Errorf("non 200 response code %d", resp.StatusCode)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "read body")
 	}


### PR DESCRIPTION
`ioutil` is deprecated from go1.16 (ref: https://go.dev/doc/go1.16#ioutil).
So removed them.

Signed-off-by: inosato <si17_21@yahoo.co.jp>
