### PR TITLE
[alert_generator] Add CORS header and support for preflight check

### DIFF
--- a/alert_generator/server.go
+++ b/alert_generator/server.go
@@ -84,6 +84,13 @@ func newAlertsServer(port string, disabled bool, logger log.Logger, messageParse
 }
 
 func (as *alertsServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
+	// some proxies/sinks like webhook.site might use a preflight check
+	if req.Method == http.MethodOptions {
+		res.Header().Set("Access-Control-Allow-Origin", "*")
+		res.Header().Set("Access-Control-Allow-Method", "POST")
+		res.WriteHeader(http.StatusOK)
+		return
+	}
 	now := time.Now().UTC()
 	b, err := io.ReadAll(req.Body)
 	if err != nil {
@@ -193,6 +200,7 @@ Outer2:
 
 	as.expectedAlertsMtx.Unlock()
 
+	res.Header().Set("Access-Control-Allow-Origin", "*")
 	res.WriteHeader(http.StatusOK)
 }
 

--- a/alert_generator/server.go
+++ b/alert_generator/server.go
@@ -84,7 +84,7 @@ func newAlertsServer(port string, disabled bool, logger log.Logger, messageParse
 }
 
 func (as *alertsServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
-	// some proxies/sinks like webhook.site might use a preflight check
+	// Some proxies/sinks like webhook.site might use a preflight check.
 	if req.Method == http.MethodOptions {
 		res.Header().Set("Access-Control-Allow-Origin", "*")
 		res.Header().Set("Access-Control-Allow-Method", "POST")


### PR DESCRIPTION
This PR adds the needed CORS header so that sinks like webhook.site can use the browser as a proxy to access the local network.

Prior to this PR this approach would cause errors and warnings on the client side.