### PR TITLE
Set offset for the query end time to -12 minutes

### DIFF
--- a/promql/cmd/promql-compliance-tester/main.go
+++ b/promql/cmd/promql-compliance-tester/main.go
@@ -113,7 +113,7 @@ func main() {
 
 	comp := comparer.New(refAPI, testAPI, cfg.QueryTweaks)
 
-	end := getTime(cfg.QueryTimeParameters.EndTime, time.Now().UTC().Add(-2*time.Minute))
+	end := getTime(cfg.QueryTimeParameters.EndTime, time.Now().UTC().Add(-12*time.Minute))
 	start := end.Add(
 		-getNonZeroDuration(cfg.QueryTimeParameters.RangeInSeconds, 10*time.Minute))
 	resolution := getNonZeroDuration(


### PR DESCRIPTION
When running the PromQL Compliance test, we can sometimes observe the queries with negative offset failing. The reason for this is that by default query end time is `now() - 2m`. And we have queries with negative offsets of -5m and -10m. That, generally, means that we are querying into the future for 3m for the first query (with `offset -5`), and 8m for the second query (with `offset -10`). When running the compliance test, sometimes a race condition can be observed with data ingestion where one storage still hasn't ingested the same sample that the other system already has ingested. As a result, queries with negative offsets into the future can fail since the resulting time series will have additional samples at the end (the one that the other storage system still hasn't ingested at that point in time). This issue is raised in #94.

This PR offsets the query end time to `-12m` (previously it was `-2m`). This will ensure that even for the query with `offset -10` we don't query into the future and thus we avoid the ingestion race condition problem.