### PR TITLE
Store and use archived filename in the bin directory

### DIFF
--- a/remote_write_sender/README.md
+++ b/remote_write_sender/README.md
@@ -35,6 +35,8 @@ The repo tests the following remote write senders:
 - The [VictoriaMetrics Agent](https://github.com/VictoriaMetrics/VictoriaMetrics/tree/master/app/vmagent), unless you're on [Mac OS X](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/1042).
 - [Timber.io Vector](https://github.com/timberio/vector).
 
-If you want to test a dev version of your sender, simply put your binary in `bin/`.
+If you want to test a dev version of your sender, simply put your binary in `bin/` using the same name of the binary that is in the published artifact.
+
+Example: for OpenTelemetry collector, the published artifact is `otelcol_0.42.0_linux_amd64.tar.gz` and the binary inside of it is `otelcol`.
 
 To add another sender, see the examples in [the targets director](targets/) and recreate that pattern in a PR.

--- a/remote_write_sender/targets/common.go
+++ b/remote_write_sender/targets/common.go
@@ -58,16 +58,10 @@ func downloadBinaryUnlocked(urlPattern string, filenameInArchivePattern string) 
 		return "", err
 	}
 
-	filename := path.Join(cwd, "bin", path.Base(parsed.Path))
-	decompressTgz := strings.HasSuffix(filename, ".tar.gz")
-	if decompressTgz {
-		filename = strings.TrimSuffix(filename, ".tar.gz")
-	}
-
-	decompressZip := strings.HasSuffix(filename, ".zip")
-	if decompressZip {
-		filename = strings.TrimSuffix(filename, ".zip")
-	}
+	filename := path.Join(cwd, "bin", filenameInArchive)
+	publishedArtifactName := path.Base(parsed.Path)
+	decompressTgz := strings.HasSuffix(publishedArtifactName, ".tar.gz")
+	decompressZip := strings.HasSuffix(publishedArtifactName, ".zip")
 
 	// If we've already downloaded it, then skip.
 	if _, err := os.Stat(filename); !os.IsNotExist(err) {


### PR DESCRIPTION
In the case of the remote_write_sender tests, use the archived filename

This will solve https://github.com/prometheus/compliance/issues/97