### PR TITLE
Disable metric suffixing in OTel PRW exporter to pass compliance tests

### DIFF
--- a/remotewrite/sender/targets/otel.go
+++ b/remotewrite/sender/targets/otel.go
@@ -29,6 +29,7 @@ processors:
 exporters:
   prometheusremotewrite:
     endpoint: '%s'
+    add_metric_suffixes: false
 
 service:
   pipelines:


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35119

The counter was being renamed to counter_total.  Disable suffixing so that we pass the compliance test.