### PR TITLE
Cleanup deprecated package

### DIFF
--- a/promql/cmd/promql-compliance-tester/main.go
+++ b/promql/cmd/promql-compliance-tester/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"math"
 	"net/http"
@@ -12,7 +13,6 @@ import (
 	"time"
 
 	"github.com/cheggaaa/pb/v3"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/api"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/compliance/promql/comparer"
@@ -29,7 +29,7 @@ func newPromAPI(targetConfig config.TargetConfig) (v1.API, error) {
 	}
 	client, err := api.NewClient(apiConfig)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating Prometheus API client for %q: %v", targetConfig.QueryURL, err)
+		return nil, fmt.Errorf("error creating Prometheus API client for %q: %w", targetConfig.QueryURL, err)
 	}
 
 	return v1.NewAPI(client), nil
@@ -180,5 +180,5 @@ func parseTime(s string) (time.Time, error) {
 	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
 		return t, nil
 	}
-	return time.Time{}, errors.Errorf("cannot parse %q to a valid timestamp", s)
+	return time.Time{}, fmt.Errorf("cannot parse %q to a valid timestamp", s)
 }

--- a/promql/comparer/comparer.go
+++ b/promql/comparer/comparer.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/pkg/errors"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/compliance/promql/config"
@@ -91,7 +90,7 @@ func (c *Comparer) Compare(tc *TestCase) (*Result, error) {
 
 	if (refErr != nil) != tc.ShouldFail {
 		if refErr != nil {
-			return nil, errors.Wrapf(refErr, "querying reference API for %q", tc.Query)
+			return nil, fmt.Errorf("error querying reference API for %q: %w", tc.Query, refErr)
 		}
 		return nil, fmt.Errorf("expected reference API query %q to fail, but succeeded", tc.Query)
 	}

--- a/promql/config/config.go
+++ b/promql/config/config.go
@@ -2,9 +2,9 @@ package config
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"gopkg.in/yaml.v2"
 )
@@ -65,15 +65,15 @@ func LoadFromFiles(filenames []string) (*Config, error) {
 	for _, f := range filenames {
 		content, err := os.ReadFile(f)
 		if err != nil {
-			return nil, errors.Wrapf(err, "reading config file %s", f)
+			return nil, fmt.Errorf("error reading config file %s: %w", f, err)
 		}
 		if _, err := buf.Write(content); err != nil {
-			return nil, errors.Wrapf(err, "appending config file %s to buffer", f)
+			return nil, fmt.Errorf("error appending config file %s to buffer: %w", f, err)
 		}
 	}
 	cfg, err := Load(buf.Bytes())
 	if err != nil {
-		return nil, errors.Wrapf(err, "parsing YAML files %s", filenames)
+		return nil, fmt.Errorf("error parsing YAML files %s: %w", filenames, err)
 	}
 	return cfg, nil
 }

--- a/promql/go.mod
+++ b/promql/go.mod
@@ -5,7 +5,6 @@ go 1.22
 require (
 	github.com/cheggaaa/pb/v3 v3.1.5
 	github.com/google/go-cmp v0.6.0
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/common v0.60.1
 	go.uber.org/atomic v1.11.0

--- a/promql/go.sum
+++ b/promql/go.sum
@@ -39,8 +39,6 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v1.20.5 h1:cxppBPuYhUnsO6yo/aoRol4L7q7UFfdm+bR9r+8l63Y=

--- a/promql/output/html.go
+++ b/promql/output/html.go
@@ -1,12 +1,12 @@
 package output
 
 import (
+	"fmt"
 	"html/template"
 	"log"
 	"os"
 	"path"
 
-	"github.com/pkg/errors"
 	"github.com/prometheus/compliance/promql/comparer"
 	"github.com/prometheus/compliance/promql/config"
 )
@@ -45,7 +45,7 @@ var funcMap = map[string]interface{}{
 func HTML(tplFile string) (Outputter, error) {
 	t, err := template.New(path.Base(tplFile)).Funcs(funcMap).ParseFiles(tplFile)
 	if err != nil {
-		return nil, errors.Wrapf(err, "parsing template file %q", tplFile)
+		return nil, fmt.Errorf("error parsing template file %q: %w", tplFile, err)
 	}
 
 	return func(results []*comparer.Result, includePassing bool, tweaks []*config.QueryTweak) {


### PR DESCRIPTION
Replace archived `github.com/pkg/errors` with standard library error handling.