### PR TITLE
update links to openmetrics to reference the v1.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The [alert_generator](alert_generator/README.md) directory contains a shim at th
 
 ## OpenMetrics
 
-The [openmetrics](openmetrics/README.md) directory contains a reference to the [OpenMetrics](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md) test suite.
+The [openmetrics](openmetrics/README.md) directory contains a reference to the [OpenMetrics](https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md) test suite.
 
 ## PromQL
 

--- a/openmetrics/README.md
+++ b/openmetrics/README.md
@@ -1,6 +1,6 @@
 # OpenMetrics compliance tester
 
-While [OpenMetrics](https://openmetrics.io/) is an independent CNCF project, Prometheus designated it as the [official specification](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md) for Prometheus exposition. OpenMetrics is, and will remain, closely aligned to Prometheus.
+While [OpenMetrics](https://openmetrics.io/) is an independent CNCF project, Prometheus designated it as the [official specification](https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md) for Prometheus exposition. OpenMetrics is, and will remain, closely aligned to Prometheus.
 
 The test suite can be found on [GitHub](https://github.com/OpenObservability/OpenMetrics/tree/main/src/cmd/openmetricstest). Depending on your implementation, the [individual test cases](https://github.com/OpenObservability/OpenMetrics/tree/main/tests/testdata/parsers) might be of direct interest.
 


### PR DESCRIPTION
Related to https://github.com/prometheus/OpenMetrics/issues/287

The OM 2.0 effort is kicked off, and will start developing on main. This updates the links to OpenMetrics to reference the 1.0 release. The OM project has also been moved into the prometheus github org.