### PR TITLE
Remove query with holt_winters function

### DIFF
--- a/promql/promql-test-queries.yml
+++ b/promql/promql-test-queries.yml
@@ -234,8 +234,6 @@ test_cases:
     query: 'histogram_quantile(0.9, demo_memory_usage_bytes)'
   - # Missing "le" label only in some series of the same grouping.
     query: 'histogram_quantile(0.9, {__name__=~"demo_api_request_duration_seconds_.+"})'
-  - query: 'holt_winters(demo_disk_usage_bytes[10m], {{.smoothingFactor}}, {{.trendFactor}})'
-    variant_args: ['smoothingFactor', 'trendFactor']
   - query: 'count_values("value", demo_api_request_duration_seconds_bucket)'
   - query: 'absent(demo_memory_usage_bytes)'
   - query: 'absent(nonexistent_metric_name)'


### PR DESCRIPTION
In `Prometheus 3.x` (commit [c7fb618](https://github.com/prometheus/prometheus/commit/c7fb6188b4340bb7794992bd592e408566cae96e)) the `holt_winters` function has been renamed to `double_exponential_smoothing` and has been moved under the experimental functions. This PR removes the query with the `holt_winters` function from the test suite.