### PR TITLE
Revert "Add fallback scrape protocol to OTel collector"

### DIFF
--- a/remotewrite/sender/targets/otel.go
+++ b/remotewrite/sender/targets/otel.go
@@ -20,7 +20,6 @@ receivers:
       scrape_configs:
         - job_name: 'test'
           scrape_interval: 1s
-          fallback_scrape_protocol: "PrometheusText0.0.4"
           static_configs:
             - targets: [ '%s' ]
 


### PR DESCRIPTION
Reverts prometheus/compliance#134

The PR solved the [compliance test for the PR that updates the dependency to 3.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/13077886194/job/36494390295?pr=36873), but breaks everywhere else. 

I'll revert this revert once we're ready to update the dependency in the collector 🫠 