### PR TITLE
Add fallback scrape protocol to OTel-Collector config

### DIFF
--- a/remotewrite/sender/targets/otel.go
+++ b/remotewrite/sender/targets/otel.go
@@ -20,6 +20,7 @@ receivers:
       scrape_configs:
         - job_name: 'test'
           scrape_interval: 1s
+          fallback_scrape_protocol: "PrometheusText0.0.4"
           static_configs:
             - targets: [ '%s' ]
 


### PR DESCRIPTION
In preparation for the update of the Prometheus lib in the collector to 0.3xx.*

Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/36873