### PR TITLE
remotewrite/otel: Remove `fallback_scrape_protocol`

### DIFF
--- a/remotewrite/sender/targets/otel.go
+++ b/remotewrite/sender/targets/otel.go
@@ -20,7 +20,6 @@ receivers:
       scrape_configs:
         - job_name: 'test'
           scrape_interval: 1s
-          fallback_scrape_protocol: "PrometheusText0.0.4"
           static_configs:
             - targets: [ '%s' ]
 


### PR DESCRIPTION
Fallback_scrape_protocol isn't needed since 1.20.1