### PR TITLE
Update otel target to handle breaking change

### DIFF
--- a/remotewrite/sender/targets/otel.go
+++ b/remotewrite/sender/targets/otel.go
@@ -40,6 +40,9 @@ service:
               prometheus:
                 host: 'localhost'
                 port: 0
+				without_scope_info: true
+				without_type_suffix: true
+				without_units: true
   pipelines:
     metrics:
       receivers: [prometheus]

--- a/remotewrite/sender/targets/otel.go
+++ b/remotewrite/sender/targets/otel.go
@@ -5,7 +5,7 @@ import (
 	"os"
 )
 
-const otelDownloadURL = "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.42.0/otelcol_0.42.0_{{.OS}}_{{.Arch}}.tar.gz"
+const otelDownloadURL = "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.123.1/otelcol_0.123.1_{{.OS}}_{{.Arch}}.tar.gz"
 
 func RunOtelCollector(opts TargetOptions) error {
 	binary, err := downloadBinary(otelDownloadURL, "otelcol")
@@ -31,7 +31,15 @@ exporters:
     endpoint: '%s'
     add_metric_suffixes: false
 
-service:
+service:  
+  telemetry:
+    metrics:
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: 'localhost'
+                port: 0
   pipelines:
     metrics:
       receivers: [prometheus]
@@ -44,5 +52,5 @@ service:
 	}
 	defer os.Remove(configFileName)
 
-	return runCommand(binary, opts.Timeout, `--set=service.telemetry.metrics.address=:0`, fmt.Sprintf("--config=%s", configFileName))
+	return runCommand(binary, opts.Timeout, fmt.Sprintf("--config=%s", configFileName))
 }


### PR DESCRIPTION
The [v0.123.0 release of collector core](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.123.0) has promoted a feature gate to beta that removes support for `service.telemetry.metrics.address`. As of v0.123.0 this setting does nothing unless the feature gate is disabled.

Since the collector is moving away from `service.telemetry.metrics.address` in favor of the otel sdk configuration, this PR updates the otel target to use the otel go's metrics SDK to export metrics via prometheus.

Collector contrib has a [workflow](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/workflows/prometheus-compliance-tests.yml) that is failing right now because of the breaking change, but this PR will fix it.

Closes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39105