### PR TITLE
[remotewrite/sender/otel] Remove additional `without` config

### DIFF
--- a/remotewrite/sender/targets/otel.go
+++ b/remotewrite/sender/targets/otel.go
@@ -40,9 +40,6 @@ service:
               prometheus:
                 host: 'localhost'
                 port: 0
-				without_scope_info: true
-				without_type_suffix: true
-				without_units: true
   pipelines:
     metrics:
       receivers: [prometheus]


### PR DESCRIPTION
In https://github.com/prometheus/compliance/pull/160 we updated the collector's config to use the OTEL SDK's prometheus exporter. We added a couple `without` config options, but these make the tests fail. 

I'm not sure why CI passed, but I can consistently get the tests to fail if these config options are included but they consistently pass if they are all removed.

Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39105