### PR TITLE
alert_generator/testsuite: fix 'occured' -> 'occurred' typo in Error() doc

### DIFF
--- a/alert_generator/testsuite.go
+++ b/alert_generator/testsuite.go
@@ -410,7 +410,7 @@ func (ts *TestSuite) Wait() {
 	ts.wg.Wait()
 }
 
-// Error() returns any error occured during execution of test and does
+// Error() returns any error occurred during execution of test and does
 // not tell if the tests passed or failed.
 func (ts *TestSuite) Error() error {
 	merr := NewMulti()


### PR DESCRIPTION
Doc comment on `testsuite.Error()` in `alert_generator/testsuite.go:413` read `returns any error occured during execution of test`. Doc-only change.