### PR TITLE
ci(compliance-tests): declare contents: read

### DIFF
--- a/.github/workflows/compliance-tests.yml
+++ b/.github/workflows/compliance-tests.yml
@@ -3,6 +3,9 @@ name: Compliance Tests
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   remotewrite-compliance:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to read-only for the only workflow in this repo. `go test` against the remote-write sender; no GitHub API writes.